### PR TITLE
UPD: Modified main task to evaluate whether to install python-pip or python3-pip

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,15 +13,25 @@
 # limitations under the License.
 ---
 - name: Check to see if pip is already installed.
-  command: "pip --version"
+  command: "pip --version || pip3 --version"
   ignore_errors: true
   changed_when: false # read-only task
   check_mode: no
   register: pip_is_installed
 
+- name: Setting python-pip as the package to install
+  set_fact:
+    pip_package: python-pip
+  when: ansible_distribution_major_version|int <= 7
+
+- name: Setting python3-pip as the package to install
+  set_fact:
+    pip_package: python3-pip
+  when: ansible_distribution_major_version|int >= 8
+
 - name: Install pip
   yum:
-    name: python-pip
+    name: "{{ pip_package }}"
     state: latest
     enablerepo: epel
   when: pip_is_installed.rc != 0


### PR DESCRIPTION
@Frawless I have made a small change to the ansible-pip role in order to install python3-pip on RHEL8 and python-pip if using an older version. As I am not sure if this role is intended for other distros, I would like to request you to review it. If needed, maybe we should add an extra condition to check for OS family as well.